### PR TITLE
Update fritzbox2mqtt.py

### DIFF
--- a/fritzbox2mqtt.py
+++ b/fritzbox2mqtt.py
@@ -46,7 +46,7 @@ def parseArgs(argv):
 
 def parseConfig(filename):
     try:
-        return yaml.load(open(filename, "r"))
+        return yaml.load(open(filename, "r"), Loader=yaml.FullLoader)
     except Exception as e:
         raise
         logging.error("Can't load yaml file %r (%r)" % (filename, e))


### PR DESCRIPTION
Correct deprecated yaml.load() call.

YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.